### PR TITLE
feat:  회원 가입 시 이메일 인증 기능 구현

### DIFF
--- a/src/main/java/shop/tryit/web/member/MemberController.java
+++ b/src/main/java/shop/tryit/web/member/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,11 +66,11 @@ public class MemberController {
      */
     @PostMapping("/email")
     public ResponseEntity<String> authEmail(@RequestBody @Valid EmailRequest emailRequest) {
+        log.info("member email controller");
         String authKey = memberFacade.authEmail(emailRequest);
         //성공했다면 인증번호와 함께 200 통신
         return new ResponseEntity<>(authKey, HttpStatus.OK);
     }
-
 
     /**
      * 로그인

--- a/src/main/resources/templates/members/register.html
+++ b/src/main/resources/templates/members/register.html
@@ -97,8 +97,8 @@
           </tr>
           <tr>
             <td>
-              <input class="table_input width70" type="text" placeholder="인증번호를 입력해주세요">
-              <input class="table_input width30" type="button" value="인증번호 확인"/>
+              <input id="authNum" class="table_input width70" type="text" placeholder="인증번호를 입력해주세요">
+              <input id="check_authNum" class="table_input width30" type="button" value="인증번호 확인"/>
             </td>
           </tr>
 
@@ -162,6 +162,8 @@
 
 <script th:inline="javascript">
   /** ====== Email Auth ====== **/
+  let resultAuthNum = 0; //인증번호 저장 전역변수
+
   $("#check_email").click(function () {
     let email = $("#email").val();
     let data = {
@@ -174,8 +176,10 @@
       url    : "/members/email",
       contentType: 'application/json',
       data   : JSON.stringify(data),
-      success: function(result) {
-        let msg = '인증번호가 발송되었습니다.';
+      success: function onData (result) {
+        console.log(result);
+        resultAuthNum = result
+        let msg = '📩 인증번호가 발송되었습니다.' + /n;
         msg += '이메일을 확인해주세요.';
         alert(msg);
       },
@@ -183,6 +187,14 @@
         alert(jqXHR.responseText);
       }
     });
+  });
+
+  $("#check_authNum").click(function () {
+    if(resultAuthNum == $("#authNum").val()){
+      alert("이메일 인증이 완료되었습니다 😊");
+    } else {
+      alert("인증번호가 일치 하지 않습니다. 다시 입력해주세요.");
+    }
   });
 
 </script>

--- a/src/main/resources/templates/members/register.html
+++ b/src/main/resources/templates/members/register.html
@@ -88,14 +88,20 @@
           </colgroup>
           <tbody>
           <tr>
-            <th><span>아이디</span></th>
+            <th rowspan="2"><span>아이디</span></th>
             <td>
-              <input class="table_input" type="email" th:field="*{email}" placeholder="ex) abcdef1234@gmail.com">
+              <input class="table_input width70" type="email" id="email" th:field="*{email}" placeholder="ex) abcdef1234@gmail.com">
+              <input id="check_email" class="table_input width30" type="button" value="인증번호 발송"/>
               <div class="field-error" th:errors="*{email}"></div>
-              <input class="table_input width70" type="text" placeholder="인증번호를 입력해주세요">
-              <input class="table_input width30" type="button" value="인증번호 발송"/>
             </td>
           </tr>
+          <tr>
+            <td>
+              <input class="table_input width70" type="text" placeholder="인증번호를 입력해주세요">
+              <input class="table_input width30" type="button" value="인증번호 확인"/>
+            </td>
+          </tr>
+
           <tr>
             <th><span>이름</span></th>
             <td>
@@ -153,5 +159,32 @@
 
 <!-- ======= Footer ======= -->
 <footer th:replace="fragments/footer :: footer" id="footer"></footer>
+
+<script th:inline="javascript">
+  /** ====== Email Auth ====== **/
+  $("#check_email").click(function () {
+    let email = $("#email").val();
+    let data = {
+      email : email
+    };
+    console.log(data);
+
+    $.ajax({
+      type   : "POST",
+      url    : "/members/email",
+      contentType: 'application/json',
+      data   : JSON.stringify(data),
+      success: function(result) {
+        let msg = '인증번호가 발송되었습니다.';
+        msg += '이메일을 확인해주세요.';
+        alert(msg);
+      },
+      error  : function(jqXHR) {
+        alert(jqXHR.responseText);
+      }
+    });
+  });
+
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 회원 가입 시 이메일 인증 기능 구현

## 📋 작업사항
- 이메일로 받은 인증 번호를 입력하여 해당 이메일이 실제로 있는 이메일인지 인증하는 과정을 추가

## ❓ 문제점/이슈
- 인증 번호 발송부터 비교까지 가능하나, 이메일 인증이 되지 않았을 경우 회원 가입을 진행 할 수 없도록 해야 한다.
