### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/shop/tryit/config/WebSecurityConfig.java
+++ b/src/main/java/shop/tryit/config/WebSecurityConfig.java
@@ -34,7 +34,7 @@ public class WebSecurityConfig {
                 .csrf().disable()
                 .authorizeRequests() //요청에 의한 보안 검사 시작
                 .antMatchers("/", "/css/**", "/img/**", "/js/**", "/vendor/**", "/files/**",
-                        "/members/new", "/members/email","/members/login", "/members/logout", "/members/vendor/**",
+                        "/members/new", "/members/email","/members/login", "/members/logout", "/members/vendor/**", "/members/delete",
                         "/items", "/items/{id}", "/items/vendor/**", "/qna", "/notices", "/notices/{noticeId}").permitAll()
                 .antMatchers("/members/update", "/carts", "/carts/{cartItemId}/update", "/carts/{cartItemId}/delete",
                         "/qna/new", "/qna/{questionId}", "/qna/{questionId}/update", "/qna/{questionId}/delete",

--- a/src/main/java/shop/tryit/domain/member/dto/EmailRequest.java
+++ b/src/main/java/shop/tryit/domain/member/dto/EmailRequest.java
@@ -9,6 +9,6 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class EmailRequest {
     @Email
-    @NotBlank(message = "이메일 인증은 필수입니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 }

--- a/src/main/java/shop/tryit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/shop/tryit/domain/member/repository/MemberRepository.java
@@ -7,6 +7,8 @@ public interface MemberRepository {
 
     Long save(Member member);
 
+    void delete(Member member);
+
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);

--- a/src/main/java/shop/tryit/domain/member/service/MemberFacade.java
+++ b/src/main/java/shop/tryit/domain/member/service/MemberFacade.java
@@ -3,6 +3,7 @@ package shop.tryit.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.member.dto.EmailRequest;
 import shop.tryit.domain.member.dto.MemberFormDto;
 import shop.tryit.domain.member.entity.Address;
@@ -11,12 +12,14 @@ import shop.tryit.domain.member.entity.MemberRole;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberFacade {
     private final MemberService memberService;
 
     /**
      * 회원 가입
      */
+    @Transactional
     public Long register(MemberFormDto memberForm) {
         MemberRole role = MemberRole.USER;
         Address address = toAddress(memberForm);
@@ -36,6 +39,7 @@ public class MemberFacade {
     /**
      * 회원 수정 업데이트
      */
+    @Transactional
     public String update(MemberFormDto memberForm) {
         Address address = toAddress(memberForm);
         Member member = toEntity(memberForm, address);
@@ -47,6 +51,15 @@ public class MemberFacade {
      */
     public String authEmail(EmailRequest emailRequest) {
         return memberService.authEmail(emailRequest);
+    }
+
+    /**
+     * 회원 탈퇴(삭제)
+     */
+    @Transactional
+    public void delete(String email) {
+        Member member = memberService.findMember(email);
+        memberService.delete(member);
     }
 
     public Member toEntity(MemberFormDto memberFormDto, Address address, MemberRole role) {

--- a/src/main/java/shop/tryit/domain/member/service/MemberService.java
+++ b/src/main/java/shop/tryit/domain/member/service/MemberService.java
@@ -5,7 +5,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.member.dto.EmailRequest;
 import shop.tryit.domain.member.entity.Member;
 import shop.tryit.domain.member.repository.MemberRepository;
@@ -14,7 +13,6 @@ import javax.mail.internet.MimeMessage;
 import java.util.Random;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -22,7 +20,6 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JavaMailSender javaMailSender;
 
-    @Transactional
     public Long saveMember(Member member) {
         validateDuplicateMember(member);
         String encodedPassword = passwordEncoder.encode(member.getPassword());
@@ -41,7 +38,6 @@ public class MemberService {
         }
     }
 
-    @Transactional
     public String update(String email, Member newMember) {
         Member findMember = findMember(email);
         String newEncodedPassword = passwordEncoder.encode(newMember.getPassword());
@@ -54,7 +50,6 @@ public class MemberService {
     /**
      * 이메일 인증번호 전송
      */
-    @Transactional
     public String authEmail(EmailRequest emailRequest) {
         Random random = new Random();
         String authKey = String.valueOf(random.nextInt(888888) + 111111); // 범위 : 111111 ~ 999999
@@ -82,4 +77,10 @@ public class MemberService {
         }
     }
 
+    /**
+     * 회원 탈퇴(삭제)
+     */
+    public void delete(Member member) {
+        repository.delete(member);
+    }
 }

--- a/src/main/java/shop/tryit/repository/member/MemberRepositoryImpl.java
+++ b/src/main/java/shop/tryit/repository/member/MemberRepositoryImpl.java
@@ -21,6 +21,11 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
+    public void delete(Member member) {
+        jpaRepository.delete(member);
+    }
+
+    @Override
     public boolean existsByEmail(String email) {
         return jpaRepository.existsByEmail(email);
     }

--- a/src/main/java/shop/tryit/web/member/MemberController.java
+++ b/src/main/java/shop/tryit/web/member/MemberController.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -121,6 +121,18 @@ public class MemberController {
 
         return "members/update";
 
+    }
+
+    /**
+     * 회원 탈퇴(삭제)
+     * TODO: view 구현 완료 후 EmailRequest -> User 로 변경하기
+     */
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> delete(@RequestBody @Valid EmailRequest emailRequest) {
+        log.info("member delete controller");
+        memberFacade.delete(emailRequest.getEmail());
+
+        return new ResponseEntity<>(HttpStatus.OK); //200
     }
 
 }

--- a/src/test/java/shop/tryit/domain/member/MemberServiceTests.java
+++ b/src/test/java/shop/tryit/domain/member/MemberServiceTests.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import shop.tryit.domain.member.entity.Member;
+import shop.tryit.domain.member.repository.MemberRepository;
 import shop.tryit.domain.member.service.MemberService;
 import shop.tryit.repository.member.MemberJpaRepository;
 
@@ -21,6 +22,9 @@ class MemberServiceTests {
 
     @Autowired
     private MemberJpaRepository memberJpaRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private EntityManager entityManager;
@@ -92,6 +96,24 @@ class MemberServiceTests {
         assertThatThrownBy(() -> sut.findMember("test1234@gmail.com"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("해당 회원을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void 회원_탈퇴_테스트() {
+        //given
+        Member member1 = Member.builder()
+                .email("test1234@gmail.com")
+                .name("test")
+                .password("11111")
+                .build();
+
+        Member savedmember = memberJpaRepository.save(member1);
+
+        //when
+        sut.delete(member1);
+
+        //then
+        assertThat(memberRepository.findByEmail(savedmember.getEmail()).isPresent()).isFalse();
     }
 
 }


### PR DESCRIPTION
## 🚅 PR 한 줄 요약
- 회원 탈퇴 기능 구현

## 📋 작업사항
- 회원 탈퇴 기능 구현
- Postman과 테스트 코드로 회원 탈퇴(삭제) 확인 완료

## 📌다음 작업 사항
- 회원 탈퇴 페이지 생성
- 회원 탈퇴 동의 체크 후 탈퇴 할 수 있도록 구현
- 동의 체크가 되지 않았다면 얼럿을 통해 메시지 출력
(예: 동의사항을 체크해야 탈퇴가 가능합니다.)